### PR TITLE
Add iteration to the Simulator and Engines.

### DIFF
--- a/pynsim/engines/engine.py
+++ b/pynsim/engines/engine.py
@@ -24,6 +24,7 @@ class Engine(object):
         self.timestep = None
         #indicates numerically the current timestep
         self.timestep_idx = None
+        self.iteration = None
     
     def run(self):
         pass

--- a/pynsim/simulators/simulator.py
+++ b/pynsim/simulators/simulator.py
@@ -16,22 +16,60 @@
 #    along with PyNSim.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-
 import time
 
-import multiprocessing
+
+class EngineIterator:
+    """ Iterator and context manager for running engines.
+
+    This object can be used as a context manager for iterating engines within
+    a `Simulator`. Within the context the manager can be used as an iterator
+    to cycle through the engines, in order, for a number of iterations. Iteration
+    is termined if `max_iterations` are reached or one of the engines raises
+    a `StopIteration` exception within the context.
+    """
+    def __init__(self, simulator, max_iterations=1):
+        self.simulator = simulator
+        self.max_iterations = max_iterations
+        self._current_engine_index = None
+        self._current_iteration = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if isinstance(exc_type, StopIteration):
+            # Stop iteration is a valid exception to stop the context/iteration
+            return False
+        return True
+
+    def __iter__(self):
+        self._current_engine_index = 0
+        self._current_iteration = 1
+        return self
+
+    def __next__(self):
+        current_engine = self.simulator.engines[self._current_engine_index]
+        current_iteration = self._current_iteration
+        if current_iteration > self.max_iterations:
+            raise StopIteration
+        self._current_engine_index = (self._current_engine_index + 1) % len(self.simulator.engines)
+        if self._current_engine_index == 0:
+            self._current_iteration += 1
+        return current_iteration, current_engine
 
 
 class Simulator(object):
 
     network = None
 
-    def __init__(self, network=None, record_time=False, progress=False):
+    def __init__(self, network=None, record_time=False, progress=False, max_iterations=1):
         self.engines = []
         #User defined timeseps
         self.timesteps = []
         self.record_time = record_time
         self.network = network
+        self.max_iterations = max_iterations
         # Track the cumilative time of the setup functions for the network,
         # nodes links and institutions. Also tracks the cumulative time of each
         # engine run. This dict should show where a slow-down is occurring. For
@@ -96,18 +134,23 @@ class Simulator(object):
                 self.timing['nodes']        += setup_timing['nodes']
 
             logging.debug("Starting engines")
-            for engine in self.engines:
-                logging.debug("Running engine %s", engine.name)
+            # Cycle through the engines up to the maximum number of iterations
+            # The context manager catches any `StopIteration` exceptions from the engines
+            # and terminates the context.
+            with EngineIterator(self, max_iterations=self.max_iterations) as manager:
+                for iteration, engine in manager:
+                    logging.debug("Running engine %s", engine.name)
 
-                if self.record_time:
-                    t = time.time()
+                    if self.record_time:
+                        t = time.time()
 
-                engine.timestep = timestep
-                engine.timestep_idx = idx
-                engine.run()
+                    engine.iteration = iteration
+                    engine.timestep = timestep
+                    engine.timestep_idx = idx
+                    engine.run()
 
-                if self.record_time:
-                    self.timing['engines'][engine.name] += time.time() - t
+                    if self.record_time:
+                        self.timing['engines'][engine.name] += time.time() - t
 
             self.network.post_process()
 

--- a/pynsim/simulators/simulator.py
+++ b/pynsim/simulators/simulator.py
@@ -38,10 +38,10 @@ class EngineIterator:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if isinstance(exc_type, StopIteration):
+        if exc_type is StopIteration:
             # Stop iteration is a valid exception to stop the context/iteration
-            return False
-        return True
+            return True
+        return False
 
     def __iter__(self):
         self._current_engine_index = 0
@@ -140,7 +140,6 @@ class Simulator(object):
             with EngineIterator(self, max_iterations=self.max_iterations) as manager:
                 for iteration, engine in manager:
                     logging.debug("Running engine %s", engine.name)
-
                     if self.record_time:
                         t = time.time()
 

--- a/test/test_iteration.py
+++ b/test/test_iteration.py
@@ -24,6 +24,16 @@ class StopperEngine(Engine):
             raise StopIteration()
 
 
+class TypeErrorEngine(Engine):
+    def __init__(self, *args, **kwargs):
+        self.error_on_iteration = kwargs.pop('error_on_iteration', 1)
+        super(TypeErrorEngine, self).__init__(*args, **kwargs)
+
+    def run(self):
+        if self.iteration >= self.error_on_iteration:
+            raise TypeError('Something went wrong!')
+
+
 class TestIteration(unittest.TestCase):
     """ Test simulator iteration settings. """
     def test_default_iteration(self):
@@ -71,6 +81,19 @@ class TestIteration(unittest.TestCase):
         assert engine.iteration == 1
         assert engine.run_count == 1
         assert stopper_engine.iteration == 2
+
+    def test_engine_error(self):
+        """ Test an engine can raises a non-StopIteration error.
+        """
+        s = Simulator(max_iterations=5)
+        s.network = Network("Iteration test network")
+
+        s.add_engine(TypeErrorEngine(None, error_on_iteration=1))
+        s.add_engine(CountEngine(None))
+        s.timesteps = [0, ]
+
+        with self.assertRaises(TypeError):
+            s.start()
 
 
 if __name__ == '__main__':

--- a/test/test_iteration.py
+++ b/test/test_iteration.py
@@ -1,0 +1,78 @@
+from pynsim import Simulator, Network, Node, Engine
+import unittest
+
+
+class CountEngine(Engine):
+    def __init__(self, *args, **kwargs):
+        super(CountEngine, self).__init__(*args, **kwargs)
+        self.run_count = None
+
+    def initialise(self):
+        self.run_count = 0
+
+    def run(self):
+        self.run_count += 1
+
+
+class StopperEngine(Engine):
+    def __init__(self, *args, **kwargs):
+        self.stop_on_iteration = kwargs.pop('stop_on_iteration', 1)
+        super(StopperEngine, self).__init__(*args, **kwargs)
+
+    def run(self):
+        if self.iteration >= self.stop_on_iteration:
+            raise StopIteration()
+
+
+class TestIteration(unittest.TestCase):
+    """ Test simulator iteration settings. """
+    def test_default_iteration(self):
+        """ Test that the default simulation `max_iterations` is one. """
+        s = Simulator()
+        s.network = Network("Iteration test network")
+        engine = CountEngine(None)
+        s.add_engine(engine)
+
+        s.timesteps = [0, ]
+        s.start()
+
+        assert engine.iteration == 1
+        assert engine.run_count == 1
+
+    def test_engine_iteration(self):
+        """ Test setting the global number of iterations in a simulator. """
+        s = Simulator(max_iterations=5)
+        s.network = Network("Iteration test network")
+        engine = CountEngine(None)
+        s.add_engine(engine)
+
+        s.timesteps = [0, ]
+        s.start()
+
+        assert engine.iteration == 5
+        assert engine.run_count == 5
+
+    def test_engine_stopping_iteration(self):
+        """ Test an engine terminating iteration
+
+        The engine must raise a `StopIteration` exception.
+        """
+        s = Simulator(max_iterations=5)
+        s.network = Network("Iteration test network")
+
+        stopper_engine = StopperEngine(None, stop_on_iteration=2)
+        s.add_engine(stopper_engine)
+        engine = CountEngine(None)
+        s.add_engine(engine)
+
+        s.timesteps = [0, ]
+        s.start()
+
+        assert engine.iteration == 1
+        assert engine.run_count == 1
+        assert stopper_engine.iteration == 2
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Simulator can now perform multiple iterations of the engines. It does this with a new
context manager and iterator. The context manager creates a context in which StopIteration
exceptions are caught for terminating iteration. The iterator will cycle the Simulator.engines
until iteration is complete. Simulator takes a max_iteration keyword argument to define an upper
limit (default=1). Engine objects also have an attribute which is updated with the current iteration.