### PR TITLE
Provide Simulator.initialise to perform initialisation.

### DIFF
--- a/pynsim/simulators/simulator.py
+++ b/pynsim/simulators/simulator.py
@@ -121,7 +121,7 @@ class Simulator(object):
 
         logging.info("Starting simulation")
 
-        if initialise:
+        if initialise is True:
             self.initialise()
 
         for idx, timestep in tqdm(enumerate(self.timesteps),

--- a/pynsim/simulators/simulator.py
+++ b/pynsim/simulators/simulator.py
@@ -91,7 +91,21 @@ class Simulator(object):
         my_engines = ",".join([m.name for m in self.engines])
         return "Simulator(engines=[%s])" % (my_engines)
 
-    def start(self):
+    def initialise(self):
+        logging.info("Initialising simulation")
+        if self.network is None:
+            logging.critical("No network to simulate!")
+            return
+
+        if len(self.timesteps) == 0:
+            logging.critical("No timesteps specified!")
+            return
+
+        for engine in self.engines:
+            logging.debug("Setting up engine %s", engine.name)
+            engine.initialise()
+
+    def start(self, initialise=True):
         # Provide dummy function to simplify code below
         def tqdm(iterable, **kwargs):
             return iterable
@@ -107,17 +121,8 @@ class Simulator(object):
 
         logging.info("Starting simulation")
 
-        if self.network is None:
-            logging.critical("No network to simulate!")
-            return
-
-        if len(self.timesteps) == 0:
-            logging.critical("No timesteps specified!")
-            return
-
-        for engine in self.engines:
-            logging.debug("Setting up engine %s", engine.name)
-            engine.initialise()
+        if initialise:
+            self.initialise()
 
         for idx, timestep in tqdm(enumerate(self.timesteps),
                                   total=len(self.timesteps)):


### PR DESCRIPTION
Useful method if one wishes to run initialise without doing the
simulation. Optional keyword argument to start can skip
initialisation if required. User must keep track of whether this
has been done.